### PR TITLE
Add the src folder in published packages and fix typings path

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,5 +6,4 @@
 .nyc_output/
 coverage/
 rollup.config.js
-src/
 test/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist/honeycomb.min.js",
   "module": "dist/honeycomb.esm.min.js",
   "jsnext:main": "dist/honeycomb.esm.min.js",
-  "types": "dist/honeycomb.d.ts",
+  "types": "src/honeycomb.d.ts",
   "scripts": {
     "build": "npm run clean && rollup --config rollup.config.js",
     "clean": "rm -rf dist",


### PR DESCRIPTION
Currently dist/honeycomb.d.ts doesn't exist in 1.3.0's published package.

Also included the source in the published package, as is the norm.