### PR TITLE
Update .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,7 +12,8 @@
                     "last 2 Chrome versions",
                     "last 2 Firefox versions",
                     "last 2 Safari versions",
-                    "last 2 Edge versions"
+                    "last 2 Edge versions",
+                    "ie >= 11"
                 ]
             },
             "modules": false


### PR DESCRIPTION
First of all, thank you for a great project! I just started playing around with it and it is really nice!

The problem:
I'm using honeycomb in a create-react-app project and everything worked fine until I tried to do a production build. 
Running `yarn build` in the create-react-app project resulted in an error:
`Failed to minify the code from this file: ./node_modules/honeycomb-grid/dist/honeycomb.esm.min.js:1:764`

After some debugging I noticed that the error came from a few lines in the code that used template literals. Those lines were not transpiled to concatenated strings. A bit of experimenting with different `.bablerc` settings later, the error from create-react-app build was gone.

So, my proposed solution (to an issue that no one else seems to have had...), is to add "ie >= 11" to the browsers list in .babelrc. That change transpiled the template literals to concatenated strings, and the create-react-app can handle the minification during it's build process.