### PR TITLE
fix(typings): Grid#hexesInRange()

### DIFF
--- a/src/honeycomb.d.ts
+++ b/src/honeycomb.d.ts
@@ -58,6 +58,7 @@ export class Grid<T = Hex<T>> extends Array<T> {
     // defined in prototype:
     get(keyOrPoint: number | PointCoordinates): T | undefined
     hexesBetween(firstHex: T, lastHex: T): T[]
+    hexesInRange(centerHex: T, range?: number, includeCenterHex?: boolean): T[]
     neighborsOf(
         hex: T,
         directions?: CompassDirection[] | number[] | CompassDirection | number | 'all',


### PR DESCRIPTION
Thanks for the cool library! At humble beginnings in my attempt to create a hex turn-based game with excaliburjs and started using honeycomb. Noticed that `Grid#hexesInRange()` was not available in typescript, so I've added it to `honeycomb.d.ts`. Thanks!