### PR TITLE
added nearestMatchingHexes method

### DIFF
--- a/src/grid/index.js
+++ b/src/grid/index.js
@@ -76,6 +76,8 @@ export default function defineGridFactory({ extendHex, Grid, Point }) {
       get: methods.get,
       hexesBetween: methods.hexesBetween,
       hexesInRange: methods.hexesInRangeFactory({ isValidHex }),
+      horizontalBounds: methods.horizontalBounds,
+      verticalBounds: methods.verticalBounds,
       neighborsOf: methods.neighborsOfFactory({
         isValidHex,
         signedModulo,

--- a/src/grid/index.js
+++ b/src/grid/index.js
@@ -78,6 +78,8 @@ export default function defineGridFactory({ extendHex, Grid, Point }) {
       hexesInRange: methods.hexesInRangeFactory({ isValidHex }),
       horizontalBounds: methods.horizontalBounds,
       verticalBounds: methods.verticalBounds,
+      maxHorizontalDistance: methods.maxHorizontalDistance,
+      maxVerticalDistance: methods.maxVerticalDistance,
       neighborsOf: methods.neighborsOfFactory({
         isValidHex,
         signedModulo,

--- a/src/grid/index.js
+++ b/src/grid/index.js
@@ -76,6 +76,7 @@ export default function defineGridFactory({ extendHex, Grid, Point }) {
       get: methods.get,
       hexesBetween: methods.hexesBetween,
       hexesInRange: methods.hexesInRangeFactory({ isValidHex }),
+      hexesInRing: methods.hexesInRingFactory({ isValidHex }),
       horizontalBounds: methods.horizontalBounds,
       verticalBounds: methods.verticalBounds,
       maxHorizontalDistance: methods.maxHorizontalDistance,

--- a/src/grid/index.js
+++ b/src/grid/index.js
@@ -77,6 +77,7 @@ export default function defineGridFactory({ extendHex, Grid, Point }) {
       hexesBetween: methods.hexesBetween,
       hexesInRange: methods.hexesInRangeFactory({ isValidHex }),
       hexesInRing: methods.hexesInRingFactory({ isValidHex }),
+      nearestMatchingHexes: methods.nearestMatchingHexesFactory({ isValidHex }),
       horizontalBounds: methods.horizontalBounds,
       verticalBounds: methods.verticalBounds,
       maxHorizontalDistance: methods.maxHorizontalDistance,

--- a/src/grid/prototype.js
+++ b/src/grid/prototype.js
@@ -290,11 +290,7 @@ export function pointWidth() {
     return 0
   }
 
-  // sort hexes from left to right and take the first and last
-  const { 0: mostLeft, length, [length - 1]: mostRight } = this[0].isPointy()
-    ? [...this].sort((a, b) => b.s - a.s || a.q - b.q)
-    : [...this].sort((a, b) => a.q - b.q)
-
+  const {mostLeft, mostRight} = this.horizontalBounds()
   return mostRight.toPoint().x - mostLeft.toPoint().x + this[0].width()
 }
 
@@ -309,10 +305,47 @@ export function pointHeight() {
     return 0
   }
 
+  const {mostDown, mostUp} = this.verticalBounds()
+  return mostDown.toPoint().y - mostUp.toPoint().y + this[0].height()
+}
+
+
+/**
+ * @memberof Grid#
+ * @instance
+ *
+ * @returns {mostLeft}    The most left hex in the grid.
+ * @returns {mostRight}   The most right hex in the grid.
+ */
+export function horizontalBounds() {
+
+  // sort hexes from left to right and take the first and last
+  const { 0: mostLeft, length, [length - 1]: mostRight } = this[0].isPointy()
+    ? [...this].sort((a, b) => b.s - a.s || a.q - b.q)
+    : [...this].sort((a, b) => a.q - b.q)
+
+  return {
+    mostLeft,
+    mostRight,
+  }
+}
+
+/**
+ * @memberof Grid#
+ * @instance
+ *
+ * @returns {mostDown}    The most down hex in the grid.
+ * @returns {mostUp}      The most up hex in the grid.
+ */
+export function verticalBounds() {
+
   // sort hexes from top to bottom and take the first and last
   const { 0: mostUp, length, [length - 1]: mostDown } = this[0].isPointy()
     ? [...this].sort((a, b) => a.r - b.r)
     : [...this].sort((a, b) => b.s - a.s || a.r - b.r)
 
-  return mostDown.toPoint().y - mostUp.toPoint().y + this[0].height()
+  return {
+    mostDown,
+    mostUp,
+  }
 }

--- a/src/grid/prototype.js
+++ b/src/grid/prototype.js
@@ -195,6 +195,41 @@ export function hexesInRangeFactory({ isValidHex }) {
   }
 }
 
+export function nearestMatchingHexesFactory({ isValidHex }) {
+  /**
+   * @memberof Grid#
+   * @instance
+   *
+   * @param {hex} centerHex                   A hex to search hexes nearest to.
+   * @param {number} maxDistance              The max distance (in hexes) from the center hex to search.
+   * @param {function} hexFilter              The function used to determine if a hex is a match.
+   *
+   * @returns {hex[]}             An array of hexes matching hexFilter at equal distances from center Hex.
+   *                              Only hexes that are present in the grid are returned.
+   *
+   * @throws {Error} When no valid hex is passed.
+   */
+  return function nearestMatchingHexes(centerHex, maxDistance, hexFilter) {
+    if (!isValidHex(centerHex)) {
+      throw new Error(`Invalid center hex: ${centerHex}.`)
+    }
+
+    if (!this.get(centerHex)) {
+      throw new Error(`Center hex with coordinates ${centerHex} not present in grid.`)
+    }
+
+    for (let i = 1; i <= maxDistance; i++) {
+      let ring = this.hexesInRing(centerHex, i)
+      let results = ring.filter(hexFilter);
+
+      if(results.length){
+        return results;
+      }
+    }
+    return []
+  }
+}
+
 export function hexesInRingFactory({ isValidHex }) {
   /**
    * @memberof Grid#

--- a/src/grid/prototype.js
+++ b/src/grid/prototype.js
@@ -309,6 +309,33 @@ export function pointHeight() {
   return mostDown.toPoint().y - mostUp.toPoint().y + this[0].height()
 }
 
+/**
+ * @memberof Grid#
+ * @instance
+ *
+ * @returns {number}    The distance between the most left and most right hexes.
+ */
+export function maxHorizontalDistance(){
+  if (this.length === 0) {
+    return 0
+  }
+  const {mostLeft, mostRight} = this.horizontalBounds()
+  return mostLeft.distance(mostRight)
+}
+
+/**
+ * @memberof Grid#
+ * @instance
+ *
+ * @returns {number}    The distance between the most left and most right hexes.
+ */
+export function maxVerticalDistance(){
+  if (this.length === 0) {
+    return 0
+  }
+  const {mostDown, mostUp} = this.verticalBounds()
+  return mostDown.distance(mostUp)
+}
 
 /**
  * @memberof Grid#

--- a/src/grid/prototype.js
+++ b/src/grid/prototype.js
@@ -195,6 +195,57 @@ export function hexesInRangeFactory({ isValidHex }) {
   }
 }
 
+export function hexesInRingFactory({ isValidHex }) {
+  /**
+   * @memberof Grid#
+   * @instance
+   * @see {@link https://www.redblobgames.com/grids/hexagons/#rings|redblobgames.com}
+   *
+   * @param {hex} centerHex                   A hex to get surrounding hexes from.
+   * @param {number} radius                   The radius (in hexes) from the center hex.
+   *
+   * @returns {hex[]}             An array of hexes in a ring arrangement centered on the passed center hex.
+   *                              Only hexes that are present in the grid are returned.
+   *
+   * @throws {Error} When no valid hex is passed.
+   */
+  return function hexesInRing(centerHex, radius) {
+    if (!isValidHex(centerHex)) {
+      throw new Error(`Invalid center hex: ${centerHex}.`)
+    }
+
+    if (!this.get(centerHex)) {
+      throw new Error(`Center hex with coordinates ${centerHex} not present in grid.`)
+    }
+
+    let hexes = []
+
+    const { q, r, s } = centerHex
+    let cube = {
+      q,
+      r: r - radius,
+      s: s + radius
+    }
+    for (let i = 0; i < 6; i++) {
+      for (let j = 0; j < radius; j++) {
+        let hex = this.get(centerHex.cubeToCartesian(cube))
+        if(hex){
+          hexes.push(hex)
+        }
+
+        const { q, r, s } = DIRECTION_COORDINATES[i]
+        cube = {
+          q: cube.q + q,
+          r: cube.r + r,
+          s: cube.s + s
+        }
+      }
+    }
+
+    return hexes
+  }
+}
+
 export function neighborsOfFactory({ isValidHex, signedModulo, compassToNumberDirection }) {
   /**
    * @memberof Grid#

--- a/src/grid/prototype.spec.js
+++ b/src/grid/prototype.spec.js
@@ -470,3 +470,51 @@ describe('pointHeight', () => {
     })
   })
 })
+
+
+describe('maxHorizontalDistance', () => {
+  describe('when the grid contains no hexes', () => {
+    it('returns 0', () => {
+      const grid = GridFactory()
+      expect(grid.maxHorizontalDistance()).to.equal(0)
+    })
+  })
+
+  describe('when the grid contains pointy hexes', () => {
+    let GridFactory,
+      options = { width: 4, height: 2 }
+
+    beforeEach(() => {
+      const Hex = extendHex({ orientation: 'pointy', size: 20 })
+      GridFactory = defineGridFactory({ extendHex, Grid, Point })(Hex)
+    })
+
+    it('returns max horizontal distance', () => {
+      expect(GridFactory.rectangle({ ...options, direction: 0 }).maxHorizontalDistance()).to.equal(4)
+      expect(GridFactory.rectangle({ ...options, direction: 1 }).maxHorizontalDistance()).to.equal(4)
+      expect(GridFactory.rectangle({ ...options, direction: 2 }).maxHorizontalDistance()).to.equal(4)
+      expect(GridFactory.rectangle({ ...options, direction: 3 }).maxHorizontalDistance()).to.equal(4)
+      expect(GridFactory.rectangle({ ...options, direction: 4 }).maxHorizontalDistance()).to.equal(3)
+      expect(GridFactory.rectangle({ ...options, direction: 5 }).maxHorizontalDistance()).to.equal(3)
+    })
+  })
+
+  describe('when the grid contains flat hexes', () => {
+    let GridFactory,
+      options = { width: 4, height: 2 }
+
+    beforeEach(() => {
+      const Hex = extendHex({ orientation: 'flat', size: 20 })
+      GridFactory = defineGridFactory({ extendHex, Grid, Point })(Hex)
+    })
+
+    it('returns max horizontal distance', () => {
+      expect(GridFactory.rectangle({ ...options, direction: 0 }).maxHorizontalDistance()).to.equal(2)
+      expect(GridFactory.rectangle({ ...options, direction: 1 }).maxHorizontalDistance()).to.equal(3)
+      expect(GridFactory.rectangle({ ...options, direction: 2 }).maxHorizontalDistance()).to.equal(3)
+      expect(GridFactory.rectangle({ ...options, direction: 3 }).maxHorizontalDistance()).to.equal(3)
+      expect(GridFactory.rectangle({ ...options, direction: 4 }).maxHorizontalDistance()).to.equal(3)
+      expect(GridFactory.rectangle({ ...options, direction: 5 }).maxHorizontalDistance()).to.equal(2)
+    })
+  })
+})


### PR DESCRIPTION
primary feature added is the `Grid.prototype.nearestMatchingHexes` method. 

A few other methods have been added to support this feature. 

Tests and documentation have not been completed yet. I want to confirm that this PR will be considered before putting in the effort.