### PR TITLE
Fix: Orientation being used as type and value

### DIFF
--- a/playground/index.ts
+++ b/playground/index.ts
@@ -1,4 +1,4 @@
-import { at, Compass, createHexPrototype, Grid, Hex, inStore, move, Orientation, rectangle } from '../dist'
+import { at, Compass, createHexPrototype, Grid, Hex, inStore, move, rectangle } from '../dist'
 import { createSuite } from './benchmark'
 import { render } from './render'
 
@@ -8,8 +8,8 @@ interface CustomHex extends Hex {
 
 const hexPrototype = createHexPrototype<CustomHex>({
   dimensions: 30,
-  orientation: Orientation.POINTY,
-  custom: 'custom', // fixme: adding `orientation: 'flat'` makes this an error, adding `orientation: Orientation.FLAT` doesn't
+  orientation: 'POINTY',
+  custom: 'custom',
   origin: 'topLeft',
 })
 // const hex = createHex(hexPrototype, { q: 4, r: 3 })

--- a/src/grid/functions/neighborOf.test.ts
+++ b/src/grid/functions/neighborOf.test.ts
@@ -4,7 +4,7 @@ import { neighborOf } from './neighborOf'
 
 describe('pointy hexes', () => {
   test(`returns the neighboring hex in unambiguous directions (bordering on the hex's side)`, () => {
-    const hexPrototype = createHexPrototype({ orientation: 'pointy' })
+    const hexPrototype = createHexPrototype({ orientation: 'POINTY' })
     const pointyHex = createHex(hexPrototype, { q: 1, r: 2 })
 
     expect(neighborOf(pointyHex, CompassDirection.NE)).toMatchObject(pointyHex.clone({ q: 2, r: 1 }))
@@ -16,7 +16,7 @@ describe('pointy hexes', () => {
   })
 
   test(`returns the neighboring hex in ambiguous directions (N and S) for a hex with a negative offset`, () => {
-    const negativeOffsetHexPrototype = createHexPrototype({ orientation: 'pointy', offset: -1 })
+    const negativeOffsetHexPrototype = createHexPrototype({ orientation: 'POINTY', offset: -1 })
     const evenRowHex = createHex(negativeOffsetHexPrototype, { q: 1, r: 2 })
     const oddRowHex = createHex(negativeOffsetHexPrototype, { q: 0, r: 3 })
 
@@ -27,7 +27,7 @@ describe('pointy hexes', () => {
   })
 
   test(`returns the neighboring hex in ambiguous directions (N and S) for a hex with a positive offset`, () => {
-    const positiveOffsetHexPrototype = createHexPrototype({ orientation: 'pointy', offset: 1 })
+    const positiveOffsetHexPrototype = createHexPrototype({ orientation: 'POINTY', offset: 1 })
     const evenRowHex = createHex(positiveOffsetHexPrototype, { q: 1, r: 2 })
     const oddRowHex = createHex(positiveOffsetHexPrototype, { q: 0, r: 3 })
 
@@ -40,7 +40,7 @@ describe('pointy hexes', () => {
 
 describe('flat hexes', () => {
   test(`returns the neighboring hex in unambiguous directions (bordering on the hex's side)`, () => {
-    const flatHexPrototype = createHexPrototype({ orientation: 'flat' })
+    const flatHexPrototype = createHexPrototype({ orientation: 'FLAT' })
     const flatHex = createHex(flatHexPrototype, { q: 1, r: 2 })
 
     expect(neighborOf(flatHex, CompassDirection.N)).toMatchObject(flatHex.clone({ q: 1, r: 1 }))
@@ -52,7 +52,7 @@ describe('flat hexes', () => {
   })
 
   test(`returns the neighboring hex in ambiguous directions (E and W) for a hex with a negative offset`, () => {
-    const negativeOffsetHexPrototype = createHexPrototype({ orientation: 'flat', offset: -1 })
+    const negativeOffsetHexPrototype = createHexPrototype({ orientation: 'FLAT', offset: -1 })
     const evenColHex = createHex(negativeOffsetHexPrototype, { q: 2, r: 0 })
     const oddColHex = createHex(negativeOffsetHexPrototype, { q: 1, r: 1 })
 
@@ -63,7 +63,7 @@ describe('flat hexes', () => {
   })
 
   test(`returns the neighboring hex in ambiguous directions (E and W) for a hex with a positive offset`, () => {
-    const positiveOffsetHexPrototype = createHexPrototype({ orientation: 'flat', offset: 1 })
+    const positiveOffsetHexPrototype = createHexPrototype({ orientation: 'FLAT', offset: 1 })
     const evenRowHex = createHex(positiveOffsetHexPrototype, { q: 2, r: 0 })
     const oddRowHex = createHex(positiveOffsetHexPrototype, { q: 1, r: 1 })
 

--- a/src/hex/functions/corners.test.ts
+++ b/src/hex/functions/corners.test.ts
@@ -1,12 +1,12 @@
-import { Orientation } from '../types'
+import { Orientation, Orientations } from '../types'
 import { corners } from './corners'
 import { createHex } from './createHex'
 import { createHexPrototype } from './createHexPrototype'
 
 test('returns corners relative to the hex, when a hex is passed', () => {
-  const pointyHexPrototype = createHexPrototype({ orientation: 'pointy', dimensions: 1 })
+  const pointyHexPrototype = createHexPrototype({ orientation: 'POINTY', dimensions: 1 })
   const pointyHex = createHex(pointyHexPrototype, { q: 1, r: 2 })
-  const flatHexPrototype = createHexPrototype({ orientation: 'flat', dimensions: 1 })
+  const flatHexPrototype = createHexPrototype({ orientation: 'FLAT', dimensions: 1 })
   const flatHex = createHex(flatHexPrototype, { q: 1, r: 2 })
 
   expect(corners(pointyHex)).toEqual([
@@ -29,12 +29,12 @@ test('returns corners relative to the hex, when a hex is passed', () => {
 
 test(`returns corners relative to any hex's origin, when hex settings are passed`, () => {
   const pointyHexSettings = {
-    orientation: Orientation.POINTY,
+    orientation: Orientations.POINTY,
     dimensions: { xRadius: 1, yRadius: 1 },
     origin: { x: 1, y: 2 },
   }
   const flatHexSettings = {
-    orientation: Orientation.FLAT,
+    orientation: Orientations.FLAT,
     dimensions: { xRadius: 1, yRadius: 1 },
     origin: { x: 1, y: 2 },
   }

--- a/src/hex/functions/corners.ts
+++ b/src/hex/functions/corners.ts
@@ -1,4 +1,4 @@
-import { Hex, HexSettings, Orientation, Point } from '../types'
+import { Hex, HexSettings, Orientations, Point } from '../types'
 import { heightFlat, heightPointy } from './height'
 import { hexToPoint } from './hexToPoint'
 import { isHex } from './isHex'
@@ -32,7 +32,7 @@ export function corners(hexOrHexSettings: Omit<HexSettings, 'offset'>): Point[] 
     dimensions: { xRadius, yRadius },
   } = hexOrHexSettings
   const point = isHex(hexOrHexSettings) ? hexToPoint(hexOrHexSettings) : hexOrHexSettings.origin
-  return orientation === Orientation.POINTY
+  return orientation === Orientations.POINTY
     ? cornersPointy(widthPointy(xRadius), heightPointy(yRadius), point)
     : cornersFlat(widthFlat(xRadius), heightFlat(yRadius), point)
 }

--- a/src/hex/functions/createHexPrototype.test.ts
+++ b/src/hex/functions/createHexPrototype.test.ts
@@ -1,5 +1,5 @@
 import { Ellipse } from '../../../dist'
-import { BoundingBox, HexCoordinates, HexPrototype, Orientation } from '../types'
+import { BoundingBox, HexCoordinates, HexPrototype, Orientations } from '../types'
 import { cloneHex } from './cloneHex'
 import { corners } from './corners'
 import { createHex } from './createHex'
@@ -20,7 +20,7 @@ test('returns the default hex prototype when no options are passed', () => {
       configurable: true,
     },
     orientation: {
-      value: Orientation.POINTY,
+      value: Orientations.POINTY,
       writable: true,
       enumerable: true,
       configurable: true,
@@ -163,10 +163,10 @@ describe('dimensions', () => {
   })
 
   test('accepts a rectangular bounding box', () => {
-    const pointyPrototype = createHexPrototype({ orientation: 'pointy', dimensions: { width: 10, height: 20 } })
+    const pointyPrototype = createHexPrototype({ orientation: 'POINTY', dimensions: { width: 10, height: 20 } })
     expect(pointyPrototype.dimensions).toEqual({ xRadius: 5.773502691896258, yRadius: 10 })
 
-    const flatPrototype = createHexPrototype({ orientation: 'flat', dimensions: { width: 10, height: 20 } })
+    const flatPrototype = createHexPrototype({ orientation: 'FLAT', dimensions: { width: 10, height: 20 } })
     expect(flatPrototype.dimensions).toEqual({ xRadius: 5, yRadius: 11.547005383792516 })
   })
 
@@ -194,10 +194,10 @@ describe('dimensions', () => {
 })
 
 describe('orientation', () => {
-  test(`accepts Orientation, 'pointy' or 'flat'`, () => {
-    expect(createHexPrototype({ orientation: Orientation.POINTY }).orientation).toBe(Orientation.POINTY)
-    expect(createHexPrototype({ orientation: 'pointy' }).orientation).toBe(Orientation.POINTY)
-    expect(createHexPrototype({ orientation: 'flat' }).orientation).toBe(Orientation.FLAT)
+  test(`accepts Orientation, 'POINTY' or 'FLAT'`, () => {
+    expect(createHexPrototype({ orientation: Orientations.POINTY }).orientation).toBe(Orientations.POINTY)
+    expect(createHexPrototype({ orientation: 'POINTY' }).orientation).toBe(Orientations.POINTY)
+    expect(createHexPrototype({ orientation: 'FLAT' }).orientation).toBe(Orientations.FLAT)
   })
 })
 

--- a/src/hex/functions/createHexPrototype.ts
+++ b/src/hex/functions/createHexPrototype.ts
@@ -1,5 +1,5 @@
 import { isFunction, isObject, isPoint } from '../../utils'
-import { BoundingBox, Ellipse, Hex, HexPrototype, HexSettings, Orientation, Point } from '../types'
+import { BoundingBox, Ellipse, Hex, HexPrototype, HexSettings, Orientation, Orientations, Point } from '../types'
 import { cloneHex } from './cloneHex'
 import { corners } from './corners'
 import { equals } from './equals'
@@ -13,7 +13,7 @@ import { width } from './width'
 
 export const defaultHexSettings: HexSettings = {
   dimensions: { xRadius: 1, yRadius: 1 },
-  orientation: Orientation.POINTY,
+  orientation: Orientations.POINTY,
   origin: { x: 0, y: 0 },
   offset: -1,
 }
@@ -113,7 +113,7 @@ export interface OriginFn {
 
 export interface HexPrototypeOptions {
   dimensions: Ellipse | BoundingBox | number
-  orientation: Orientation | 'pointy' | 'flat'
+  orientation: Orientation
   origin: Point | 'topLeft' | OriginFn
   offset: number
 }
@@ -128,7 +128,7 @@ function normalizeDimensions(prototype: HexPrototypeOptions) {
 
     const { width, height } = dimensions as BoundingBox
     if (width > 0 && height > 0) {
-      return normalizeOrientation(prototype) === Orientation.POINTY
+      return normalizeOrientation(prototype) === Orientations.POINTY
         ? { xRadius: width / Math.sqrt(3), yRadius: height / 2 }
         : { xRadius: width / 2, yRadius: height / Math.sqrt(3) }
     }
@@ -144,9 +144,9 @@ function normalizeDimensions(prototype: HexPrototypeOptions) {
 }
 
 function normalizeOrientation({ orientation }: HexPrototypeOptions) {
-  orientation = orientation.toUpperCase() as Orientation
+  orientation = orientation as Orientation
 
-  if (orientation === Orientation.POINTY || orientation === Orientation.FLAT) {
+  if (orientation === Orientations.POINTY || orientation === Orientations.FLAT) {
     return orientation
   }
 

--- a/src/hex/functions/height.test.ts
+++ b/src/hex/functions/height.test.ts
@@ -3,9 +3,9 @@ import { createHexPrototype } from './createHexPrototype'
 import { height } from './height'
 
 test(`returns the hex's height`, () => {
-  const pointyHexPrototype = createHexPrototype({ orientation: 'pointy', dimensions: { xRadius: 1, yRadius: 1 } })
+  const pointyHexPrototype = createHexPrototype({ orientation: 'POINTY', dimensions: { xRadius: 1, yRadius: 1 } })
   const pointyHex = createHex(pointyHexPrototype)
-  const flatHexPrototype = createHexPrototype({ orientation: 'flat', dimensions: { xRadius: 1, yRadius: 1 } })
+  const flatHexPrototype = createHexPrototype({ orientation: 'FLAT', dimensions: { xRadius: 1, yRadius: 1 } })
   const flatHex = createHex(flatHexPrototype)
 
   expect(height(pointyHex)).toBe(2)

--- a/src/hex/functions/height.ts
+++ b/src/hex/functions/height.ts
@@ -1,8 +1,8 @@
-import { HexSettings, Orientation } from '../types'
+import { HexSettings, Orientations } from '../types'
 
 export const heightPointy = (yRadius: number) => yRadius * 2
 
 export const heightFlat = (yRadius: number) => yRadius * Math.sqrt(3)
 
 export const height = ({ orientation, dimensions: { yRadius } }: HexSettings) =>
-  orientation === Orientation.POINTY ? heightPointy(yRadius) : heightFlat(yRadius)
+  orientation === Orientations.POINTY ? heightPointy(yRadius) : heightFlat(yRadius)

--- a/src/hex/functions/hexToOffset.test.ts
+++ b/src/hex/functions/hexToOffset.test.ts
@@ -3,13 +3,13 @@ import { createHexPrototype } from './createHexPrototype'
 import { hexToOffset } from './hexToOffset'
 
 test(`returns a hex's offset (col, row) coordinates`, () => {
-  const pointyOddOffsetHexPrototype = createHexPrototype({ orientation: 'pointy', offset: -1 })
+  const pointyOddOffsetHexPrototype = createHexPrototype({ orientation: 'POINTY', offset: -1 })
   const pointyOddOffsetHex = createHex(pointyOddOffsetHexPrototype, { q: 1, r: 3 })
-  const pointyEvenOffsetHexPrototype = createHexPrototype({ orientation: 'pointy', offset: 1 })
+  const pointyEvenOffsetHexPrototype = createHexPrototype({ orientation: 'POINTY', offset: 1 })
   const pointyEvenOffsetHex = createHex(pointyEvenOffsetHexPrototype, { q: 1, r: 3 })
-  const flatOddOffsetHexPrototype = createHexPrototype({ orientation: 'flat', offset: -1 })
+  const flatOddOffsetHexPrototype = createHexPrototype({ orientation: 'FLAT', offset: -1 })
   const flatOddOffsetHex = createHex(flatOddOffsetHexPrototype, { q: 1, r: 3 })
-  const flatEvenOffsetHexPrototype = createHexPrototype({ orientation: 'flat', offset: 1 })
+  const flatEvenOffsetHexPrototype = createHexPrototype({ orientation: 'FLAT', offset: 1 })
   const flatEvenOffsetHex = createHex(flatEvenOffsetHexPrototype, { q: 1, r: 3 })
 
   expect(hexToOffset(pointyOddOffsetHex)).toEqual({ col: 2, row: 3 })

--- a/src/hex/functions/hexToPoint.test.ts
+++ b/src/hex/functions/hexToPoint.test.ts
@@ -4,13 +4,13 @@ import { hexToPoint } from './hexToPoint'
 
 test('returns the point relative to the origin of the passed hex', () => {
   const pointyHexPrototype = createHexPrototype({
-    orientation: 'pointy',
+    orientation: 'POINTY',
     origin: { x: 1, y: 1 },
     dimensions: { xRadius: 1, yRadius: 1 },
   })
   const pointyHex = createHex(pointyHexPrototype, { q: 1, r: 2 })
   const flatHexPrototype = createHexPrototype({
-    orientation: 'flat',
+    orientation: 'FLAT',
     origin: { x: 1, y: 1 },
     dimensions: { xRadius: 1, yRadius: 1 },
   })

--- a/src/hex/functions/hexToPoint.ts
+++ b/src/hex/functions/hexToPoint.ts
@@ -1,7 +1,7 @@
-import { Hex, Orientation, Point } from '../types'
+import { Hex, Orientations, Point } from '../types'
 
 export const hexToPoint = ({ orientation, dimensions: { xRadius, yRadius }, origin: { x, y }, q, r }: Hex): Point =>
-  orientation === Orientation.POINTY
+  orientation === Orientations.POINTY
     ? {
         x: xRadius * Math.sqrt(3) * (q + r / 2) - x,
         y: ((yRadius * 3) / 2) * r - y,

--- a/src/hex/functions/isFlat.test.ts
+++ b/src/hex/functions/isFlat.test.ts
@@ -3,9 +3,9 @@ import { createHexPrototype } from './createHexPrototype'
 import { isFlat } from './isFlat'
 
 test('returns whether the passed hex has a flat orientation', () => {
-  const pointyHexPrototype = createHexPrototype({ orientation: 'pointy' })
+  const pointyHexPrototype = createHexPrototype({ orientation: 'POINTY' })
   const pointyHex = createHex(pointyHexPrototype)
-  const flatHexPrototype = createHexPrototype({ orientation: 'flat' })
+  const flatHexPrototype = createHexPrototype({ orientation: 'FLAT' })
   const flatHex = createHex(flatHexPrototype)
 
   expect(isFlat(pointyHex)).toBe(false)

--- a/src/hex/functions/isFlat.ts
+++ b/src/hex/functions/isFlat.ts
@@ -1,3 +1,3 @@
-import { HexSettings, Orientation } from '../types'
+import { HexSettings, Orientations } from '../types'
 
-export const isFlat = ({ orientation }: HexSettings) => orientation === Orientation.FLAT
+export const isFlat = ({ orientation }: HexSettings) => orientation === Orientations.FLAT

--- a/src/hex/functions/isPointy.test.ts
+++ b/src/hex/functions/isPointy.test.ts
@@ -3,9 +3,9 @@ import { createHexPrototype } from './createHexPrototype'
 import { isPointy } from './isPointy'
 
 test('returns whether the passed hex has a flat orientation', () => {
-  const pointyHexPrototype = createHexPrototype({ orientation: 'pointy' })
+  const pointyHexPrototype = createHexPrototype({ orientation: 'POINTY' })
   const pointyHex = createHex(pointyHexPrototype)
-  const flatHexPrototype = createHexPrototype({ orientation: 'flat' })
+  const flatHexPrototype = createHexPrototype({ orientation: 'FLAT' })
   const flatHex = createHex(flatHexPrototype)
 
   expect(isPointy(pointyHex)).toBe(true)

--- a/src/hex/functions/isPointy.ts
+++ b/src/hex/functions/isPointy.ts
@@ -1,3 +1,3 @@
-import { HexSettings, Orientation } from '../types'
+import { HexSettings, Orientations } from '../types'
 
-export const isPointy = ({ orientation }: HexSettings) => orientation === Orientation.POINTY
+export const isPointy = ({ orientation }: HexSettings) => orientation === Orientations.POINTY

--- a/src/hex/functions/width.test.ts
+++ b/src/hex/functions/width.test.ts
@@ -3,9 +3,9 @@ import { createHexPrototype } from './createHexPrototype'
 import { width } from './width'
 
 test(`returns the hex's width`, () => {
-  const pointyHexPrototype = createHexPrototype({ orientation: 'pointy', dimensions: { xRadius: 1, yRadius: 1 } })
+  const pointyHexPrototype = createHexPrototype({ orientation: 'POINTY', dimensions: { xRadius: 1, yRadius: 1 } })
   const pointyHex = createHex(pointyHexPrototype)
-  const flatHexPrototype = createHexPrototype({ orientation: 'flat', dimensions: { xRadius: 1, yRadius: 1 } })
+  const flatHexPrototype = createHexPrototype({ orientation: 'FLAT', dimensions: { xRadius: 1, yRadius: 1 } })
   const flatHex = createHex(flatHexPrototype)
 
   expect(width(pointyHex)).toBe(1.7320508075688772)

--- a/src/hex/functions/width.ts
+++ b/src/hex/functions/width.ts
@@ -1,8 +1,8 @@
-import { HexSettings, Orientation } from '../types'
+import { HexSettings, Orientations } from '../types'
 
 export const widthPointy = (xRadius: number) => xRadius * Math.sqrt(3)
 
 export const widthFlat = (xRadius: number) => xRadius * 2
 
 export const width = ({ orientation, dimensions: { xRadius } }: HexSettings) =>
-  orientation === Orientation.POINTY ? widthPointy(xRadius) : widthFlat(xRadius)
+  orientation === Orientations.POINTY ? widthPointy(xRadius) : widthFlat(xRadius)

--- a/src/hex/types.ts
+++ b/src/hex/types.ts
@@ -6,10 +6,12 @@ export interface Point {
   y: number
 }
 
-export enum Orientation {
-  FLAT = 'FLAT',
-  POINTY = 'POINTY',
-}
+export const Orientations = {
+  FLAT: 'FLAT',
+  POINTY: 'POINTY',
+} as const
+export type ValueOf<T> = T[keyof T]
+export type Orientation = ValueOf<typeof Orientations>
 
 export type OffsetCoordinates = {
   col: number
@@ -66,8 +68,10 @@ export interface HexPrototype extends HexSettings {
   s: number
 
   equals(this: this, coordinates: HexCoordinates): boolean
+
   // todo: about 80% sure the newProps type works (it's used in more places, if it works: maybe make it a separate type?)
   clone(this: this, newProps?: Partial<this> | HexCoordinates): this
+
   toString(this: this): string
 }
 


### PR DESCRIPTION
`Orientation` is a TS type (it's actually an enum), but in some places it's used as a string value:
`orientation === Orientation.POINTY`

You probably want to compare that `orientation` equals `'POINTY'` string here, but this is comparing that `orientation` is of type `'POINTY'` string. It's pretty-much the same thing, but just seems slightly off.

This could cause issues, because, after the TS => JS compilation, there's no more TS type `Orientation`.
A better approach is to create an `Orientations` const that can be used in TS as well as in JS, as a value.
To get the type of such const, you can use `typeof Orientations`.

To say that some value needs to be one of the `Orientations` values, you can write: `ValueOf<typeof Orientations>`,
where `type ValueOf<T> = T[keyof T]`

This change also fixes the use of `'flat'`, `'FLAT'`, `'pointy'` and `'POINTY'` to allow only uppercase versions: `'FLAT'` and `'POINTY'`.

I don't see the need to accommodate both `'FLAT'` and `'flat'`. We could also accommodate `'fLaT'` and `'not pointy'`, etc.
I think allowing only one value clears up the API. It's good that you're working on the `next` version so it's a perfect time to introduce such breaking changes.

`as const`: https://blog.logrocket.com/const-assertions-are-the-killer-new-typescript-feature-b73451f35802/
`ValueOf`: https://stackoverflow.com/questions/49285864/is-there-a-valueof-similar-to-keyof-in-typescript
