### PR TITLE
Fix broken NPM install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Honeycomb works in recent versions of Chrome, Firefox, Edge and Safari. It's rec
 NPM:
 
 ```bash
-npm i honeycomb-grid@4.0.0-alpha
+npm i honeycomb-grid@alpha
 ```
 
 Yarn:


### PR DESCRIPTION
Npm does not know how to resolve the 4.0.0-alpha version.

Fixes error
> No matching version found for honeycomb-grid@4.0.0-alpha.