### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/honeycomb-grid.mjs",
-        "types": "./dist/index.d.ts"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/honeycomb-grid.mjs"
       },
       "require": {
-        "default": "./dist/honeycomb-grid.umd.js",
-        "types": "./dist/index.d.ts"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/honeycomb-grid.umd.js"
       }
     }
   },


### PR DESCRIPTION
Fixes "Module not found: Error: Default condition should be last one" bug that stops React apps from starting.

My app stopped working a few days ago when you issued 4.1.2. Rolling back to 4.1.1 fixes the issue, as does patching 4.1.3 with the attached.